### PR TITLE
implement POWERON and POWEROFF as the power switch.  improved _getOn(…

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,7 +65,8 @@ SamsungTvAccessory.prototype._getOn = function(callback) {
     var accessory = this;
     this.remote.isAlive(function(err) {
         if (err) {
-             callback(new Error('TV is offline'));
+            accessory.log.debug('TV is offline');
+            callback(null, false);
         } else {
             accessory.log.debug('TV is ALIVE!');
             callback(null, true);
@@ -75,9 +76,17 @@ SamsungTvAccessory.prototype._getOn = function(callback) {
 
 SamsungTvAccessory.prototype._setOn = function(on, callback) {
     if (on) {
-        callback(new Error('Could not turn on TV'));
+        this.remote.send('KEY_POWERON', function(err) {
+            if (err) {
+                callback(new Error('Could not turn on TV'));
+            } else {
+		// command has been successfully transmitted to your tv,
+                // so it should be on now.
+                callback(null);
+            }
+        });
     } else {
-        this.remote.send('KEY_POWER', function(err) {
+        this.remote.send('KEY_POWEROFF', function(err) {
             if (err) {
                 callback(new Error(err));
             } else {


### PR DESCRIPTION
I converted the setOn() to call KEY_POWERON and KEY_POWEROFF.  This only returns an error if the TV powers off the network adaptor while off.  I also adjusted the logic to return off state as well as on for the _getOn() function, based on the isAlive() status result, so that HomeKit show the TV status as on/off instead of always on with errors.
